### PR TITLE
template_notebook_to_follow: fix colab url

### DIFF
--- a/template_notebook_to_follow.ipynb
+++ b/template_notebook_to_follow.ipynb
@@ -7,7 +7,7 @@
         "colab_type": "text"
       },
       "source": [
-        "<a href=\"https://colab.research.google.com/github/msaligane/sscs-ose-chipathon.github.io/blob/main/template_notebook_to_follow.ipynb\" target=\"_parent\"><img src=\"https://colab.research.google.com/assets/colab-badge.svg\" alt=\"Open In Colab\"/></a>"
+        "<a href=\"https://colab.research.google.com/github/sscs-ose/sscs-ose-chipathon.github.io/blob/main/template_notebook_to_follow.ipynb\" target=\"_parent\"><img src=\"https://colab.research.google.com/assets/colab-badge.svg\" alt=\"Open In Colab\"/></a>"
       ]
     },
     {


### PR DESCRIPTION
point to `sscs-ose` instead of `msaligane`